### PR TITLE
Fix horizontal overflow on homepage

### DIFF
--- a/src/lib/EditableWebsite.svelte
+++ b/src/lib/EditableWebsite.svelte
@@ -205,7 +205,7 @@
 
 <div
 	class={[
-		'@container/wrapper relative w-screen',
+		'@container/wrapper relative w-full',
 		showingMobileView
 			? 'bg-base-50 dark:bg-base-950 my-4 min-h-[calc(100dhv-2em)] rounded-2xl lg:mx-auto lg:w-[400px]'
 			: ''

--- a/src/lib/Website.svelte
+++ b/src/lib/Website.svelte
@@ -26,7 +26,7 @@
 	let container: HTMLDivElement | undefined = $state();
 </script>
 
-<div class="@container/wrapper relative w-screen">
+<div class="@container/wrapper relative w-full">
 	<Profile {handle} {did} {data} showEditButton={true} />
 
 	<div class="mx-auto max-w-2xl lg:grid lg:max-w-none lg:grid-cols-4 xl:grid-cols-3">


### PR DESCRIPTION
## Description
Fixes horizontal overflow bug that appears when OS scrollbars are set to always display.

## Problem
The `w-screen` class (which translates to `width: 100vw`) causes horizontal scrolling because viewport width units don't account for the scrollbar width. When scrollbars are visible, this creates an overflow equal to the scrollbar width.

## Solution
Changed `w-screen` to `w-full` in:
- `src/lib/Website.svelte`
- `src/lib/EditableWebsite.svelte`

The `w-full` class (which translates to `width: 100%`) respects the actual container width and accounts for scrollbars.

## Testing
Can be reproduced by setting macOS scrollbars to "Always" in System Settings > Appearance > Show scroll bars.