### PR TITLE
docs: add missing lexicons to Autofill.md

### DIFF
--- a/docs/Autofill.md
+++ b/docs/Autofill.md
@@ -10,4 +10,8 @@
   - pub.leaflet.document
   - blue.flashes.actor.portfolio
   - social.grain.gallery
+  - xyz.statusphere.status
+  - site.standard.publication	
+  - fm.teal.alpha.feed.play
+  - dev.npmx.feed.like
 - add bluesky profile card


### PR DESCRIPTION
## Summary
- Adds 4 lexicons to the autofill checklist in `docs/Autofill.md` that already have card implementations in the codebase but were missing from the doc:
  - `xyz.statusphere.status` (StatusphereCard)
  - `site.standard.publication` (domain verification, load.ts)
  - `fm.teal.alpha.feed.play` (TealFMPlaysCard)
  - `dev.npmx.feed.like` (NpmxLikesCard)

## Test plan
- [x] Verified each lexicon has a corresponding card implementation in `src/lib/cards/`
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)