### PR TITLE
add plyr.fm playlist and album embeds

### DIFF
--- a/src/lib/cards/index.ts
+++ b/src/lib/cards/index.ts
@@ -46,7 +46,7 @@ import { LastFMRecentTracksCardDefinition } from './media/LastFMCard/LastFMRecen
 import { LastFMTopTracksCardDefinition } from './media/LastFMCard/LastFMTopTracksCard';
 import { LastFMTopAlbumsCardDefinition } from './media/LastFMCard/LastFMTopAlbumsCard';
 import { LastFMProfileCardDefinition } from './media/LastFMCard/LastFMProfileCard';
-import { PlyrFMCardDefinition } from './media/PlyrFMCard';
+import { PlyrFMCardDefinition, PlyrFMCollectionCardDefinition } from './media/PlyrFMCard';
 import { MarginCardDefinition } from './social/MarginCard';
 import { SembleCollectionCardDefinition } from './social/SembleCollectionCard';
 // import { Model3DCardDefinition } from './visual/Model3DCard';
@@ -101,6 +101,7 @@ export const AllCardDefinitions = [
 	LastFMTopAlbumsCardDefinition,
 	LastFMProfileCardDefinition,
 	PlyrFMCardDefinition,
+	PlyrFMCollectionCardDefinition,
 	MarginCardDefinition,
 	SembleCollectionCardDefinition
 ] as const;

--- a/src/lib/cards/media/PlyrFMCard/CreatePlyrFMCardModal.svelte
+++ b/src/lib/cards/media/PlyrFMCard/CreatePlyrFMCardModal.svelte
@@ -2,7 +2,7 @@
 	import { Alert, Button, Input, Subheading } from '@foxui/core';
 	import Modal from '$lib/components/modal/Modal.svelte';
 	import type { CreationModalComponentProps } from '../../types';
-	import { toPlyrFMEmbedUrl } from './index';
+	import { toPlyrFMEmbedUrl, toPlyrFMCollectionEmbedUrl } from './index';
 
 	let { item = $bindable(), oncreate, oncancel }: CreationModalComponentProps = $props();
 
@@ -14,21 +14,27 @@
 		const embedUrl = toPlyrFMEmbedUrl(item.cardData.href);
 
 		if (!embedUrl) {
-			errorMessage = 'Please enter a valid plyr.fm track URL';
+			errorMessage = 'Please enter a valid plyr.fm URL (track, playlist, or album)';
 			return false;
 		}
 
 		item.cardData.href = embedUrl;
+
+		// resize to collection dimensions if it's a playlist or album
+		if (toPlyrFMCollectionEmbedUrl(item.cardData.href)) {
+			item.h = 5;
+			item.mobileH = 10;
+		}
 
 		return true;
 	}
 </script>
 
 <Modal open={true} closeButton={false}>
-	<Subheading>Enter a Plyr.fm track URL</Subheading>
+	<Subheading>Enter a Plyr.fm URL</Subheading>
 	<Input
 		bind:value={item.cardData.href}
-		placeholder="https://plyr.fm/track/..."
+		placeholder="https://plyr.fm/track/... or /playlist/... or /u/.../album/..."
 		onkeydown={(e) => {
 			if (e.key === 'Enter' && checkUrl()) oncreate();
 		}}

--- a/src/lib/cards/media/PlyrFMCard/PlyrFMCard.svelte
+++ b/src/lib/cards/media/PlyrFMCard/PlyrFMCard.svelte
@@ -12,7 +12,7 @@
 			frameborder="0"
 			allow="autoplay; encrypted-media"
 			loading="lazy"
-			title="Plyr.fm track"
+			title="Plyr.fm"
 		></iframe>
 	</div>
 {:else}

--- a/src/lib/cards/media/PlyrFMCard/index.ts
+++ b/src/lib/cards/media/PlyrFMCard/index.ts
@@ -2,14 +2,18 @@ import type { CardDefinition } from '../../types';
 import CreatePlyrFMCardModal from './CreatePlyrFMCardModal.svelte';
 import PlyrFMCard from './PlyrFMCard.svelte';
 
-const cardType = 'plyr-fm';
+const musicIcon = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="size-4"><path stroke-linecap="round" stroke-linejoin="round" d="m9 9 10.5-3m0 6.553v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 1 1-.99-3.467l2.31-.66a2.25 2.25 0 0 0 1.632-2.163Zm0 0V4.125A2.25 2.25 0 0 0 17.378 1.9l-7.056 2.018A2.25 2.25 0 0 0 8.69 6.08v7.353m0 0v2.929a2.25 2.25 0 0 1-1.244 2.013L6.07 19.21a1.803 1.803 0 1 1-1.758-3.14l1.88-1.003A2.25 2.25 0 0 0 7.378 13.1v-.065Z" /></svg>`;
+
+// ── Track card (existing) ────────────────────────────────────────────
+
+const trackType = 'plyr-fm';
 
 export const PlyrFMCardDefinition = {
-	type: cardType,
+	type: trackType,
 	contentComponent: PlyrFMCard,
 	creationModalComponent: CreatePlyrFMCardModal,
 	createNew: (item) => {
-		item.cardType = cardType;
+		item.cardType = trackType;
 		item.cardData = {};
 		item.w = 4;
 		item.mobileW = 8;
@@ -18,7 +22,7 @@ export const PlyrFMCardDefinition = {
 	},
 
 	onUrlHandler: (url, item) => {
-		const embedUrl = toPlyrFMEmbedUrl(url);
+		const embedUrl = toPlyrFMTrackEmbedUrl(url);
 		if (!embedUrl) return null;
 
 		item.cardData.href = embedUrl;
@@ -38,19 +42,101 @@ export const PlyrFMCardDefinition = {
 	minW: 2,
 	minH: 2,
 
-	keywords: ['music', 'song', 'plyr', 'plyrfm', 'audio'],
+	keywords: ['music', 'song', 'plyr', 'plyrfm', 'audio', 'track'],
 	groups: ['Media'],
-	icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="size-4"><path stroke-linecap="round" stroke-linejoin="round" d="m9 9 10.5-3m0 6.553v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 1 1-.99-3.467l2.31-.66a2.25 2.25 0 0 0 1.632-2.163Zm0 0V4.125A2.25 2.25 0 0 0 17.378 1.9l-7.056 2.018A2.25 2.25 0 0 0 8.69 6.08v7.353m0 0v2.929a2.25 2.25 0 0 1-1.244 2.013L6.07 19.21a1.803 1.803 0 1 1-1.758-3.14l1.88-1.003A2.25 2.25 0 0 0 7.378 13.1v-.065Z" /></svg>`
-} as CardDefinition & { type: typeof cardType };
+	icon: musicIcon
+} as CardDefinition & { type: typeof trackType };
 
-// Match plyr.fm track URLs (both embed and regular)
-// https://plyr.fm/embed/track/56
+// ── Collection card (playlists + albums) ─────────────────────────────
+
+const collectionType = 'plyr-fm-collection';
+
+export const PlyrFMCollectionCardDefinition = {
+	type: collectionType,
+	contentComponent: PlyrFMCard,
+	creationModalComponent: CreatePlyrFMCardModal,
+	createNew: (item) => {
+		item.cardType = collectionType;
+		item.cardData = {};
+		item.w = 4;
+		item.mobileW = 8;
+		item.h = 5;
+		item.mobileH = 10;
+	},
+
+	onUrlHandler: (url, item) => {
+		const embedUrl = toPlyrFMCollectionEmbedUrl(url);
+		if (!embedUrl) return null;
+
+		item.cardData.href = embedUrl;
+
+		item.w = 4;
+		item.mobileW = 8;
+		item.h = 5;
+		item.mobileH = 10;
+
+		return item;
+	},
+
+	// higher priority so collection URLs are matched before the track handler
+	urlHandlerPriority: 3,
+
+	name: 'Plyr.fm Playlist / Album',
+	canResize: true,
+	minW: 2,
+	minH: 3,
+
+	keywords: ['music', 'playlist', 'album', 'plyr', 'plyrfm', 'collection'],
+	groups: ['Media'],
+	icon: musicIcon
+} as CardDefinition & { type: typeof collectionType };
+
+// ── URL matching ─────────────────────────────────────────────────────
+
+// Match plyr.fm track URLs
 // https://plyr.fm/track/595
-export function toPlyrFMEmbedUrl(url: string | undefined): string | null {
+// https://plyr.fm/embed/track/56
+export function toPlyrFMTrackEmbedUrl(url: string | undefined): string | null {
 	if (!url) return null;
 
 	const match = url.match(/plyr\.fm\/(embed\/)?track\/(\d+)/);
 	if (!match) return null;
 
 	return `https://plyr.fm/embed/track/${match[2]}`;
+}
+
+// Match plyr.fm playlist and album URLs
+//
+// Playlists:
+//   https://plyr.fm/playlist/abc-def-123
+//   https://plyr.fm/embed/playlist/abc-def-123
+//
+// Albums:
+//   https://plyr.fm/u/handle/album/slug
+//   https://plyr.fm/embed/album/handle/slug
+export function toPlyrFMCollectionEmbedUrl(url: string | undefined): string | null {
+	if (!url) return null;
+
+	// Playlist: /playlist/{uuid} or /embed/playlist/{uuid}
+	const playlistMatch = url.match(/plyr\.fm\/(embed\/)?playlist\/([a-f0-9-]+)/i);
+	if (playlistMatch) {
+		return `https://plyr.fm/embed/playlist/${playlistMatch[2]}`;
+	}
+
+	// Album: /u/{handle}/album/{slug} or /embed/album/{handle}/{slug}
+	const albumEmbedMatch = url.match(/plyr\.fm\/embed\/album\/([^/?#]+)\/([^/?#]+)/);
+	if (albumEmbedMatch) {
+		return `https://plyr.fm/embed/album/${albumEmbedMatch[1]}/${albumEmbedMatch[2]}`;
+	}
+	const albumPageMatch = url.match(/plyr\.fm\/u\/([^/?#]+)\/album\/([^/?#]+)/);
+	if (albumPageMatch) {
+		return `https://plyr.fm/embed/album/${albumPageMatch[1]}/${albumPageMatch[2]}`;
+	}
+
+	return null;
+}
+
+// Accepts any plyr.fm URL (track, playlist, or album)
+export function toPlyrFMEmbedUrl(url: string | undefined): string | null {
+	return toPlyrFMTrackEmbedUrl(url) ?? toPlyrFMCollectionEmbedUrl(url);
 }


### PR DESCRIPTION
adds a `plyr-fm-collection` card type for [playlists and albums](https://plyr.leaflet.pub/3mesjqtrogk27), alongside the existing `plyr-fm` track card. Collections use taller defaults (`h: 5`) to show the track list. Both share the same iframe component.

<img width="253" height="110" alt="image" src="https://github.com/user-attachments/assets/01ef11f7-a4c3-40d7-b70d-71e68cac07e2" />

<img width="889" height="351" alt="image" src="https://github.com/user-attachments/assets/87046506-57e9-493a-8b18-7e0b87161361" />


<details>
<summary>URL patterns</summary>

| Type | Page URL | Embed URL |
|------|----------|-----------|
| Track (existing) | `plyr.fm/track/{id}` | `plyr.fm/embed/track/{id}` |
| Playlist | `plyr.fm/playlist/{uuid}` | `plyr.fm/embed/playlist/{uuid}` |
| Album | `plyr.fm/u/{handle}/album/{slug}` | `plyr.fm/embed/album/{handle}/{slug}` |

</details>

<details>
<summary>Design decisions</summary>

- Separate card type rather than branching in the existing track handler — follows the pattern of Livestream having `latestLivestream` + `livestreamEmbed` for different card shapes
- `urlHandlerPriority: 3` on the collection card so playlist/album URLs match before falling through to the track handler
- Playlists and albums are collapsed into one "collection" type since they render identically (same iframe, same dimensions)
- `toPlyrFMEmbedUrl` kept as a union matcher used by the shared creation modal

</details>