### PR TITLE
Fix pckt url in edit view of empty blog feed card

### DIFF
--- a/src/lib/cards/content/StandardSiteDocumentListCard/StandardSiteDocumentListCard.svelte
+++ b/src/lib/cards/content/StandardSiteDocumentListCard/StandardSiteDocumentListCard.svelte
@@ -57,7 +57,7 @@
 						class="">Leaflet</Button
 					>
 					or
-					<Button href="https://pckt.pub" target="_blank" rel="noopener noreferrer" class=""
+					<Button href="https://pckt.blog" target="_blank" rel="noopener noreferrer" class=""
 						>Pckt</Button
 					>
 				</span>


### PR DESCRIPTION
Just saw this when clicking around while setting up my https://blento.vvill.dev.

Thanks for the cool project! :)