### PR TITLE
Fix record data letter casing

### DIFF
--- a/src/lib/cards/media/TealFMPlaysCard/AlbumArt.svelte
+++ b/src/lib/cards/media/TealFMPlaysCard/AlbumArt.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	let { releaseMbId, alt }: { releaseMbId?: string; alt: string } = $props();
+	let { releaseMbid, alt }: { releaseMbid?: string; alt: string } = $props();
 
 	let isLoading = $state(true);
 	let hasError = $state(false);
@@ -25,7 +25,7 @@
 	</div>
 {:else}
 	<img
-		src="https://coverartarchive.org/release/{releaseMbId}/front-250"
+		src="https://coverartarchive.org/release/{releaseMbid}/front-250"
 		{alt}
 		class="h-10 w-10 rounded-lg object-cover {isLoading && 'hidden'}"
 		onload={() => {

--- a/src/lib/cards/media/TealFMPlaysCard/TealFMPlaysCard.svelte
+++ b/src/lib/cards/media/TealFMPlaysCard/TealFMPlaysCard.svelte
@@ -52,7 +52,7 @@
 {#snippet musicItem(play: Play)}
 	<div class="flex w-full items-center gap-3">
 		<div class="size-10 shrink-0">
-			<AlbumArt releaseMbId={play.value.releaseMbId} alt="" />
+			<AlbumArt releaseMbid={play.value.releaseMbid} alt="" />
 		</div>
 		<div class="min-w-0 flex-1">
 			<div class="inline-flex w-full max-w-full justify-between gap-2">


### PR DESCRIPTION
Fixes https://github.com/flo-bit/blento/issues/123.

I noticed that the letter casing referencing the releaseMbid data for teal.fm records was incorrect (was releaseMbId instead).

After fixing this, teal.fm album art populates almost entirely as expected - it's still imperfect as I have noticed different album art is pulled than the album the song is played from sometimes. Additionally, I've also seen some rare cases where art is still not found at all, but given I had literally none showing before, this is a significant improvement.


Before:
<img width="434" height="436" alt="teal.fm recent plays with no album art showing at all" src="https://github.com/user-attachments/assets/27ff60d7-7f24-447d-9815-9f096b288e37" />

After:
<img width="435" height="441" alt="teal.fm recent plays with album art showing" src="https://github.com/user-attachments/assets/984b995c-05fd-430e-b123-d51c950bb28f" />
