### PR TITLE
fix: sync in-memory publication URL after custom domain changes

### DIFF
--- a/src/lib/cards/core/LinkCard/LinkCardSettings.svelte
+++ b/src/lib/cards/core/LinkCard/LinkCardSettings.svelte
@@ -48,7 +48,7 @@
 		<path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
 	</svg>
 </Button>
-<div class="flex items-center space-x- mt-4">
+<div class="space-x- mt-4 flex items-center">
 	<Checkbox
 		bind:checked={
 			() => Boolean(item.cardData.showBackgroundImage),
@@ -61,7 +61,7 @@
 	<Label
 		id="show-bg-image-label"
 		for="show-bg-image"
-		class="text-sm leading-none ml-2 font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+		class="ml-2 text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 	>
 		Show background image
 	</Label>

--- a/src/lib/website/Account.svelte
+++ b/src/lib/website/Account.svelte
@@ -47,5 +47,10 @@
 		</Popover>
 	</div>
 
-	<CustomDomainModal publicationUrl={data.publication?.url} />
+	<CustomDomainModal
+		publicationUrl={data.publication?.url}
+		onurlchange={(url) => {
+			if (data.publication) data.publication.url = url;
+		}}
+	/>
 {/if}

--- a/src/lib/website/CustomDomainModal.svelte
+++ b/src/lib/website/CustomDomainModal.svelte
@@ -13,7 +13,10 @@
 	import Modal from '$lib/components/modal/Modal.svelte';
 	import { launchConfetti } from '@foxui/visual';
 
-	let { publicationUrl }: { publicationUrl?: string } = $props();
+	let {
+		publicationUrl,
+		onurlchange
+	}: { publicationUrl?: string; onurlchange?: (url: string | undefined) => void } = $props();
 
 	let currentDomain = $derived(
 		publicationUrl?.startsWith('https://') && !publicationUrl.includes('blento.app')
@@ -57,6 +60,7 @@
 			}
 
 			step = 'input';
+			onurlchange?.(undefined);
 		} catch (err: unknown) {
 			errorMessage = err instanceof Error ? err.message : String(err);
 			step = 'error';
@@ -124,6 +128,7 @@
 			}
 
 			launchConfetti();
+			onurlchange?.('https://' + domain);
 			step = 'success';
 		} catch (err: unknown) {
 			errorMessage = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## problem

when a user sets up a custom domain via the CustomDomainModal, the URL is correctly written to ATProto (`site.standard.publication` record), but the in-memory `data.publication.url` is never updated. this causes a subtle bug:

1. user verifies custom domain → ATProto record gets `url: "https://mycustomdomain.com"`
2. user edits their site and saves → `savePage()` runs
3. `savePage()` checks `if (!data.publication.url)` — but the old `blento.app/{handle}` URL is still in memory, so this guard is truthy
4. the stale `blento.app/{handle}` URL gets written back to ATProto, overwriting the custom domain URL

the same issue exists in reverse when removing a custom domain — the URL field is stripped from ATProto but stays in memory.

## impact

downstream consumers that index `site.standard.publication` records end up storing the wrong URL. for example, a document at `https://marcobonomo.dev/blog/manifesto-cucina-amatoriale` gets indexed with `https://blento.app/marcobonomo.dev/blog/manifesto-cucina-amatoriale`, which 404s.

found via https://pub-search.waow.tech/?q=%22in+una+libreria%22

## fix

add an `onUrlChange` callback prop to `CustomDomainModal`. after `verify()` succeeds, it calls back with the new `https://{domain}` URL. after `removeDomain()` succeeds, it calls back with `undefined`. `Account.svelte` wires this up to update `data.publication.url` in place.

## changes

- `CustomDomainModal.svelte`: add `onUrlChange` prop, call it after verify and remove
- `Account.svelte`: pass `onUrlChange` callback to sync `data.publication.url`