### PR TITLE
fix: add `$type` field to new records

### DIFF
--- a/src/lib/atproto/server/repo.remote.ts
+++ b/src/lib/atproto/server/repo.remote.ts
@@ -27,16 +27,29 @@ export const putRecord = command(
 		const { locals } = getRequestEvent();
 		if (!locals.client || !locals.did) error(401, 'Not authenticated');
 
+		const record =
+			input.record.$type === input.collection
+				? input.record
+				: { ...input.record, $type: input.collection };
+
 		const response = await locals.client.post('com.atproto.repo.putRecord', {
 			input: {
 				collection: input.collection as `${string}.${string}.${string}`,
 				repo: locals.did,
 				rkey: input.rkey || 'self',
-				record: input.record
+				record
 			}
 		});
 
-		if (!response.ok) error(500, 'Failed to put record');
+		if (!response.ok) {
+			console.error('putRecord failed', {
+				collection: input.collection,
+				rkey: input.rkey || 'self',
+				status: response.status,
+				data: response.data
+			});
+			error(500, 'Failed to put record');
+		}
 
 		// Immediately index in contrail
 		const { platform } = getRequestEvent();


### PR DESCRIPTION
this is a requirement for the PDS validation here which we use for @atproto.la
https://tangled.org/tranquil.farm/tranquil-pds/blob/main/crates/tranquil-api/src/repo/record/validation.rs#L24

I also included a bit more in the error output, which was how I was able to debug the issue when running locally. Seems helpful to leave the server output in the log :+1: