### PR TITLE
feat: Add Bandcamp embed card

### DIFF
--- a/src/lib/cards/index.ts
+++ b/src/lib/cards/index.ts
@@ -38,6 +38,7 @@ import { CountdownCardDefinition } from './utilities/CountdownCard';
 import { SpotifyCardDefinition } from './media/SpotifyCard';
 import { AppleMusicCardDefinition } from './media/AppleMusicCard';
 import { SoundCloudCardDefinition } from './media/SoundCloudCard';
+import { BandcampCardDefinition } from './media/BandcampCard';
 import { ButtonCardDefinition } from './utilities/ButtonCard';
 import { GuestbookCardDefinition } from './social/GuestbookCard';
 import { FriendsCardDefinition } from './social/FriendsCard';
@@ -109,6 +110,7 @@ export const AllCardDefinitions = [
 	SpotifyCardDefinition,
 	AppleMusicCardDefinition,
 	SoundCloudCardDefinition,
+	BandcampCardDefinition,
 	// Model3DCardDefinition
 	FriendsCardDefinition,
 	GitHubContributorsCardDefinition,

--- a/src/lib/cards/media/BandcampCard/BandcampCard.svelte
+++ b/src/lib/cards/media/BandcampCard/BandcampCard.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { ContentComponentProps } from '../../types';
+	import { bandcampPlayerUri, isBandcampUrl } from './shared';
+
+	let { item, isEditing }: ContentComponentProps = $props();
+
+	const src = $derived(
+		isBandcampUrl(item.cardData?.href) ? bandcampPlayerUri(item.cardData.href) : null
+	);
+</script>
+
+{#if src}
+	<div class="absolute inset-0 p-2">
+		<iframe
+			class={['h-full w-full rounded-2xl', isEditing && 'pointer-events-none']}
+			{src}
+			frameborder="0"
+			allow="autoplay"
+			loading="lazy"
+			seamless
+			title="Bandcamp player"
+		></iframe>
+	</div>
+{:else}
+	<div class="flex h-full items-center justify-center p-4 text-center opacity-50">
+		Missing Bandcamp URL
+	</div>
+{/if}

--- a/src/lib/cards/media/BandcampCard/CreateBandcampCardModal.svelte
+++ b/src/lib/cards/media/BandcampCard/CreateBandcampCardModal.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { Alert, Button, Input, Subheading } from '@foxui/core';
+	import Modal from '$lib/components/modal/Modal.svelte';
+	import type { CreationModalComponentProps } from '../../types';
+	import { isBandcampUrl } from './shared';
+
+	let { item = $bindable(), oncreate, oncancel }: CreationModalComponentProps = $props();
+
+	let errorMessage = $state('');
+
+	function checkUrl() {
+		errorMessage = '';
+		const url = item.cardData.href?.trim();
+
+		if (!isBandcampUrl(url)) {
+			errorMessage = 'Please enter a valid Bandcamp album or track URL';
+			return false;
+		}
+
+		item.cardData.href = url;
+		return true;
+	}
+</script>
+
+<Modal open={true} closeButton={false}>
+	<Subheading>Enter a Bandcamp album or track URL</Subheading>
+	<Input
+		bind:value={item.cardData.href}
+		placeholder="https://artist.bandcamp.com/album/..."
+		onkeydown={(e) => {
+			if (e.key === 'Enter' && checkUrl()) oncreate();
+		}}
+	/>
+
+	{#if errorMessage}
+		<Alert type="error" title="Invalid URL"><span>{errorMessage}</span></Alert>
+	{/if}
+
+	<div class="mt-4 flex justify-end gap-2">
+		<Button onclick={oncancel} variant="ghost">Cancel</Button>
+		<Button
+			onclick={() => {
+				if (checkUrl()) oncreate();
+			}}
+		>
+			Create
+		</Button>
+	</div>
+</Modal>

--- a/src/lib/cards/media/BandcampCard/index.ts
+++ b/src/lib/cards/media/BandcampCard/index.ts
@@ -1,0 +1,47 @@
+import type { CardDefinition } from '../../types';
+import BandcampCard from './BandcampCard.svelte';
+import CreateBandcampCardModal from './CreateBandcampCardModal.svelte';
+import { isBandcampUrl } from './shared';
+
+const cardType = 'bandcamp-embed';
+
+export const BandcampCardDefinition = {
+	type: cardType,
+	contentComponent: BandcampCard,
+	creationModalComponent: CreateBandcampCardModal,
+	createNew: (item) => {
+		item.cardType = cardType;
+		item.cardData = {};
+		item.w = 4;
+		item.mobileW = 8;
+		item.h = 5;
+		item.mobileH = 10;
+	},
+
+	onUrlHandler: (url, item) => {
+		if (!isBandcampUrl(url)) return null;
+
+		item.cardData.href = url;
+
+		item.w = 4;
+		item.mobileW = 8;
+		item.h = 5;
+		item.mobileH = 10;
+
+		return item;
+	},
+
+	urlHandlerPriority: 2,
+
+	canChange: (item) => isBandcampUrl(item.cardData?.href),
+	change: (item) => item,
+
+	name: 'Bandcamp Embed',
+	canResize: true,
+	minW: 3,
+	minH: 4,
+
+	keywords: ['music', 'album', 'track', 'bandcamp', 'audio', 'artist'],
+	groups: ['Media'],
+	icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4"><path d="M0 18.75l7.437-13.5H24l-7.438 13.5H0z"/></svg>`
+} as CardDefinition & { type: typeof cardType };

--- a/src/lib/cards/media/BandcampCard/shared.ts
+++ b/src/lib/cards/media/BandcampCard/shared.ts
@@ -1,0 +1,26 @@
+// Bandcamp's EmbeddedPlayer resolves a public album/track URL server-side via
+// its `url=` param, so no scraping/ID lookup is needed (same approach as the
+// first-party bluesky social-app embed player).
+
+// Match bandcamp.com subdomain stores only (matching bluesky's behavior).
+// Custom domains are intentionally excluded to avoid hijacking unrelated
+// `/album/` or `/track/` URLs.
+const BANDCAMP_HOST = /^[a-z\d][a-z\d-]{2,}[a-z\d]\.bandcamp\.com$/i;
+
+export function isBandcampUrl(url: string | undefined): boolean {
+	if (!url) return false;
+	try {
+		const u = new URL(url);
+		if (!BANDCAMP_HOST.test(u.hostname)) return false;
+		const kind = u.pathname.split('/')[1];
+		return kind === 'album' || kind === 'track';
+	} catch {
+		return false;
+	}
+}
+
+export function bandcampPlayerUri(url: string): string {
+	return `https://bandcamp.com/EmbeddedPlayer/url=${encodeURIComponent(
+		url
+	)}/size=large/bgcol=333333/linkcol=0f91ff/tracklist=true/transparent=true/`;
+}


### PR DESCRIPTION
## Summary

Adds a **Bandcamp** album/track card to the Media group, alongside the existing Spotify / SoundCloud / Apple Music embed cards.

Like the first-party [bluesky social-app embed player](https://github.com/bluesky-social/social-app/blob/main/src/lib/strings/embed-player.ts), it uses Bandcamp's `EmbeddedPlayer/url=<public URL>` param, so the public album/track URL resolves server-side — no page scraping, ID lookup, server route, or caching needed. The card is a plain URL→iframe embed, matching the shape of the Spotify and SoundCloud cards.

- Matches `*.bandcamp.com` `/album/` and `/track/` URLs (via `onUrlHandler` + creation modal). Custom domains are intentionally excluded, matching bluesky's behavior, to avoid hijacking unrelated `/album/` URLs.
- Registered in `src/lib/cards/index.ts`; no other files touched.

Files:
- `src/lib/cards/media/BandcampCard/{index.ts,shared.ts,BandcampCard.svelte,CreateBandcampCardModal.svelte}`

## Test plan
Local testing - 
<img width="1215" height="769" alt="image" src="https://github.com/user-attachments/assets/1fa8d16f-8300-4615-b1fe-ae64a221a0c1" />

<img width="1215" height="769" alt="image" src="https://github.com/user-attachments/assets/35e351fe-1d23-4b3b-bdc4-75cc51ee78a2" />
